### PR TITLE
add support for phpctags memory limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Configuration
 
 Location of phpctags should be in system '$PATH' environment variable.
 
-Or, the locateion of phpctags can be configured in vimrc as such:
+Or, the location of phpctags can be configured in vimrc as such:
 
     let g:tagbar_phpctags_bin='PATH_TO_phpctags'
+
+The amount of memory that phpctags can use can be configured as such:
+
+    let g:tagbar_phpctags_memory_limit = '512M'
+
+The default is 128 megabytes of memory.

--- a/plugin/tagbar-phpctags.vim
+++ b/plugin/tagbar-phpctags.vim
@@ -2,8 +2,13 @@ if !exists('g:tagbar_phpctags_bin')
     let g:tagbar_phpctags_bin = 'phpctags'
 endif
 
+if !exists('g:tagbar_phpctags_memory_limit')
+    let g:tagbar_phpctags_memory_limit = '128M'
+endif
+
 let g:tagbar_type_php = {
     \ 'ctagsbin'  : tagbar_phpctags_bin,
+    \ 'ctagsargs' : '--memory="' . tagbar_phpctags_memory_limit . '" -f',
     \ 'kinds'     : [
         \ 'd:Constants:0',
         \ 'v:Variables:0',


### PR DESCRIPTION
This change is related to techlivezheng/phpctags#5 and goes with techlivezheng/phpctags#6
