### PR TITLE
More sensible settings for folding and statusline

### DIFF
--- a/plugin/tagbar-phpctags.vim
+++ b/plugin/tagbar-phpctags.vim
@@ -5,13 +5,13 @@ endif
 let g:tagbar_type_php = {
     \ 'ctagsbin'  : tagbar_phpctags_bin,
     \ 'kinds'     : [
-        \ 'd:Constants:0',
-        \ 'v:Variables:0',
-        \ 'f:Functions:0',
+        \ 'd:Constants:0:0',
+        \ 'v:Variables:0:0',
+        \ 'f:Functions:1',
         \ 'i:Interfaces:0',
         \ 'c:Classes:0',
-        \ 'p:Properties:0',
-        \ 'm:Methods:0'
+        \ 'p:Properties:0:0',
+        \ 'm:Methods:1'
     \ ],
     \ 'sro'        : '::',
     \ 'kind2scope' : {


### PR DESCRIPTION
Changed the settings, so functions and methods start in closed foldstate and constants, variables and properties are not displayed in the statusline.

These are imho more sensible defaults, as having functions and methods open causes the list to be really long and confusing. And displaying the variables and properties in the status line is wrong most of the time, since the cursor is not on the definition but somewhere below it.
