### PR TITLE
Update: build phpctags 0.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ source := README.md \
           bin/phpctags \
           plugin/tagbar-phpctags.vim
 
-version := 0.5.1
+version := 0.6.0
 
 .PHONY: all
 all: bin/phpctags
@@ -29,15 +29,15 @@ archive: build/tagbar-phpctags-$(version).zip
 bin:
 	@mkdir bin/
 
-bin/phpctags: build/phpctags-$(version)/phpctags | bin
-	@cp build/phpctags-$(version)/phpctags $@
+bin/phpctags: build/phpctags-$(version)/build/phpctags.phar | bin
+	@cp build/phpctags-$(version)/build/phpctags.phar $@
 
 build:
 	@mkdir build/
 
 build/phpctags-$(version).zip: | build
 	@echo "Downloading phpctags ..."
-	@curl -o $@ -s -L https://github.com/techlivezheng/phpctags/archive/v$(version).zip
+	@curl -o $@ -s -L https://github.com/vim-php/phpctags/archive/$(version).zip
 	@echo "Done!"
 
 build/phpctags-$(version): build/phpctags-$(version).zip | build
@@ -45,7 +45,7 @@ build/phpctags-$(version): build/phpctags-$(version).zip | build
 	@cd build/ && unzip phpctags-$(version).zip
 	@echo "Done!"
 
-build/phpctags-$(version)/phpctags: | build/phpctags-$(version)
+build/phpctags-$(version)/build/phpctags.phar: | build/phpctags-$(version)
 	@echo "Building phpctags ..."
 	@cd build/phpctags-$(version) && $(MAKE)
 	@echo "Done!"


### PR DESCRIPTION
Just updating to phpctags 0.6.0:
- Using the one at vim-php instead of techlivezheng.
- Updating paths to find the new executable (it's under build).

The main reason to update is that v0.5.1 will error on this file:

```
<?php

function myfunc($a = 1*1) {
  $i = 0;

  return $i + 3;
}
?>
```

With output:

```
PHPParser: Unexpected token '*' on line 3 - 
!_TAG_FILE_FORMAT       2       /extended format; --format=1 will not append ;" to lines/
!_TAG_FILE_SORTED       1       /0=unsorted, 1=sorted, 2=foldcase/
!_TAG_PROGRAM_AUTHOR    techlivezheng   /techlivezheng@gmail.com/
!_TAG_PROGRAM_NAME      phpctags        //
!_TAG_PROGRAM_URL       https://github.com/techlivezheng/phpctags       /official site/
!_TAG_PROGRAM_VERSION   0.5.1   //
```
